### PR TITLE
Add arbitrary container element to hold canvases

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,11 @@
 import { CameraParams } from './camera.js'
-import { SoundPlayerParams } from './sound.js'
-import { InputsHandlerParams } from './inputs.js'
-import { RendererParams } from './renderer.js'
-import { GameStateParams } from './gameState/types.js'
-import { MessageBoxParams } from './messageBox.js'
 import { DialogParams } from './dialog.js'
+import { GameStateParams } from './gameState/types.js'
+import { InputsHandlerParams } from './inputs.js'
+import { MessageBoxParams } from './messageBox.js'
+import { RendererParams } from './renderer.js'
 import { FilterParams } from './shaders/filterSettings.js'
+import { SoundPlayerParams } from './sound.js'
 
 export type Config<T extends string> = RendererParams &
 	InputsHandlerParams &
@@ -14,9 +14,12 @@ export type Config<T extends string> = RendererParams &
 	MessageBoxParams &
 	DialogParams & { filter?: FilterParams } & GameStateParams<T> & {
 		title?: string | string[]
+	} & {
+		container: HTMLElement
 	}
 
 export const defaultConfig: Config<string> = {
+	container: document.body,
 	player: {
 		sprite: 0,
 	},

--- a/src/createGame.ts
+++ b/src/createGame.ts
@@ -22,11 +22,15 @@ export const createGame = <T extends string>(
 	const gameState = initGameState(config)
 	const soundPlayer = initSoundPlayer(config)
 	const camera = initCamera(config)
-	const renderer = initRenderer(config)
-	const dialog = initDialog(config)
-	const prompt = initPrompt(config)
-	const messageBox = initMessageBox(config)
-	const gameFilter = initFilter(renderer.canvas, config.filter)
+	const renderer = initRenderer(config, config.container)
+	const dialog = initDialog(config, config.container)
+	const prompt = initPrompt(config, config.container)
+	const messageBox = initMessageBox(config, config.container)
+	const gameFilter = initFilter(
+		renderer.canvas,
+		config.container,
+		config.filter,
+	)
 	const ender = initEnder({ gameState, messageBox, camera })
 
 	const gameLoop = initGameLoop({
@@ -36,7 +40,7 @@ export const createGame = <T extends string>(
 		ender,
 	})
 
-	initInputsHandler(config, (input) => {
+	initInputsHandler(config, config.container, (input) => {
 		if (prompt.isOpen) {
 			prompt.input(input)
 		} else if (messageBox.isOpen) {

--- a/src/dialog.ts
+++ b/src/dialog.ts
@@ -19,6 +19,7 @@ const FONT_SIZE = 8
 const BOX_OUTLINE = 2
 
 export class Dialog {
+	#container: HTMLElement
 	#canvas: HTMLCanvasElement
 	#ctx: CanvasRenderingContext2D
 	#resolvePromise?: () => void
@@ -48,7 +49,8 @@ export class Dialog {
 	#boxX: number
 	#boxY: number
 
-	constructor(params: DialogParams) {
+	constructor(params: DialogParams, container: HTMLElement) {
+		this.#container = container
 		this.#configColors = params.colors
 		this.#backgroundColor = this.#getColor(params.dialogBackground)
 		this.#contentColor = this.#getColor(params.dialogColor)
@@ -65,8 +67,8 @@ export class Dialog {
 		this.#canvas.classList.add('odyc-dialog-canvas')
 
 		this.#resizeCanvas()
-		document.body.append(this.#canvas)
-		window.addEventListener('resize', this.#resizeCanvas)
+		this.#container.append(this.#canvas)
+		this.#container.addEventListener('resize', this.#resizeCanvas)
 
 		this.#boxWidth = MAX_CHARS_PER_LINE * 8 + PADDING_X * 2
 		this.#boxHeight =
@@ -141,9 +143,12 @@ export class Dialog {
 	}
 
 	#resizeCanvas = () => {
-		const sideSize = Math.min(window.innerWidth, window.innerHeight)
-		const left = (window.innerWidth - sideSize) * 0.5
-		const top = (window.innerHeight - sideSize) * 0.5
+		const sideSize = Math.min(
+			this.#container.clientWidth,
+			this.#container.clientHeight,
+		)
+		const left = (this.#container.clientWidth - sideSize) * 0.5
+		const top = (this.#container.clientHeight - sideSize) * 0.5
 		this.#canvas.style.setProperty('width', `${sideSize}px`)
 		this.#canvas.style.setProperty('height', `${sideSize}px`)
 		this.#canvas.style.setProperty('left', `${left}px`)
@@ -180,4 +185,5 @@ export class Dialog {
 	}
 }
 
-export const initDialog = (params: DialogParams) => new Dialog(params)
+export const initDialog = (params: DialogParams, container: HTMLElement) =>
+	new Dialog(params, container)

--- a/src/filter.ts
+++ b/src/filter.ts
@@ -6,6 +6,7 @@ import {
 
 export class Filter {
 	canvas: HTMLCanvasElement
+	#container: HTMLElement
 	#settings: ReturnType<typeof getFilterSettings>
 	#uniforms: Uniforms = {}
 	#textureSource: HTMLCanvasElement
@@ -16,8 +17,13 @@ export class Filter {
 	#uniformCache = new Map<string, WebGLUniformLocation>()
 	#attributePositionLocation: GLint
 
-	constructor(target: HTMLCanvasElement, options: FilterParams) {
+	constructor(
+		target: HTMLCanvasElement,
+		options: FilterParams,
+		container: HTMLElement,
+	) {
 		this.#settings = getFilterSettings(options)
+		this.#container = container
 
 		if (this.#settings.settings)
 			for (const key in this.#settings.settings) {
@@ -37,7 +43,7 @@ export class Filter {
 		this.canvas.style.setProperty('image-rendering', 'pixelated')
 		this.canvas.classList.add('odyc-filter-canvas')
 
-		window.addEventListener('resize', this.#setSize)
+		this.#container.addEventListener('resize', this.#setSize)
 
 		const gl = this.canvas.getContext('webgl', { preserveDrawingBuffer: true })
 		if (!gl) throw new Error('WebGL not supported')
@@ -99,7 +105,10 @@ export class Filter {
 	#setSize = () => {
 		const orientation =
 			this.canvas.width < this.canvas.height ? 'vertical' : 'horizontal'
-		const sideSize = Math.min(window.innerWidth, window.innerHeight)
+		const sideSize = Math.min(
+			this.#container.clientWidth,
+			this.#container.clientHeight,
+		)
 		let width =
 			orientation === 'horizontal'
 				? sideSize
@@ -108,8 +117,8 @@ export class Filter {
 			orientation === 'vertical'
 				? sideSize
 				: (sideSize / this.canvas.width) * this.canvas.height
-		const left = (window.innerWidth - width) * 0.5
-		const top = (window.innerHeight - height) * 0.5
+		const left = (this.#container.clientWidth - width) * 0.5
+		const top = (this.#container.clientHeight - height) * 0.5
 
 		this.canvas.style.setProperty('width', `${width}px`)
 		this.canvas.style.setProperty('height', `${height}px`)
@@ -243,8 +252,9 @@ export class Filter {
 }
 export const initFilter = (
 	target: HTMLCanvasElement,
+	container: HTMLElement,
 	options?: FilterParams,
 ) => {
 	if (!options) return null
-	return new Filter(target, options)
+	return new Filter(target, options, container)
 }

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -19,7 +19,11 @@ class InputsHandler {
 	pointerId?: number
 	isSliding = false
 
-	constructor(params: InputsHandlerParams, onInput: (input: Input) => void) {
+	constructor(
+		params: InputsHandlerParams,
+		container: HTMLElement,
+		onInput: (input: Input) => void,
+	) {
 		this.controls = Object.entries(params.controls) as [
 			Input,
 			string | string[],
@@ -34,8 +38,8 @@ class InputsHandler {
 		touchEventElement.style.setProperty('height', '100vh')
 		touchEventElement.style.setProperty('overflow', 'hidden')
 		touchEventElement.style.setProperty('touch-action', 'none')
-		document.body.appendChild(touchEventElement)
-		document.body.style.setProperty('margin', '0')
+		container.appendChild(touchEventElement)
+		container.style.setProperty('margin', '0')
 
 		document.addEventListener('keydown', this.handleKeydown)
 		touchEventElement.addEventListener('pointerdown', this.handleTouch)
@@ -113,5 +117,6 @@ class InputsHandler {
 
 export const initInputsHandler = (
 	params: InputsHandlerParams,
+	container: HTMLElement,
 	onInput: (input: Input) => void,
-) => new InputsHandler(params, onInput)
+) => new InputsHandler(params, container, onInput)

--- a/src/messageBox.ts
+++ b/src/messageBox.ts
@@ -8,6 +8,7 @@ export type MessageBoxParams = {
 }
 
 export class MessageBox {
+	#container: HTMLElement
 	#canvas: HTMLCanvasElement
 	#ctx: CanvasRenderingContext2D
 	isOpen = false
@@ -32,7 +33,8 @@ export class MessageBox {
 	#paddingX = 1
 	#spaceBetweenLines = 2
 
-	constructor(params: MessageBoxParams) {
+	constructor(params: MessageBoxParams, container: HTMLElement) {
+		this.#container = container
 		this.#configColors = params.colors
 		this.#backgroundColor = this.#getColor(params.messageBackground)
 		this.#contentColor = this.#getColor(params.messageColor)
@@ -55,15 +57,18 @@ export class MessageBox {
 		this.#textFx = new TextFx('\n', this.#contentColor, this.#configColors)
 
 		this.#resize()
-		window.addEventListener('resize', this.#resize)
+		this.#container.addEventListener('resize', this.#resize)
 
-		document.body.append(this.#canvas)
+		this.#container.append(this.#canvas)
 	}
 
 	#resize = () => {
-		const sideSize = Math.min(window.innerWidth, window.innerHeight)
-		const left = (window.innerWidth - sideSize) * 0.5
-		const top = (window.innerHeight - sideSize) * 0.5
+		const sideSize = Math.min(
+			this.#container.clientWidth,
+			this.#container.clientHeight,
+		)
+		const left = (this.#container.clientWidth - sideSize) * 0.5
+		const top = (this.#container.clientHeight - sideSize) * 0.5
 		this.#canvas.style.setProperty('width', `${sideSize}px`)
 		this.#canvas.style.setProperty('height', `${sideSize}px`)
 		this.#canvas.style.setProperty('left', `${left}px`)
@@ -139,5 +144,7 @@ export class MessageBox {
 	}
 }
 
-export const initMessageBox = (params: MessageBoxParams) =>
-	new MessageBox(params)
+export const initMessageBox = (
+	params: MessageBoxParams,
+	container: HTMLElement,
+) => new MessageBox(params, container)

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -17,6 +17,7 @@ export interface MenuOption {
 }
 
 export class Prompt {
+	#container: HTMLElement
 	#canvas: HTMLCanvasElement
 	#ctx: CanvasRenderingContext2D
 	#resolvePromise?: (index: number) => void
@@ -30,7 +31,8 @@ export class Prompt {
 	#contentColor: string
 	#borderColor: string
 
-	constructor(params: DialogParams) {
+	constructor(params: DialogParams, container: HTMLElement) {
+		this.#container = container
 		this.#configColors = params.colors
 		this.#backgroundColor = this.#getColor(params.dialogBackground)
 		this.#contentColor = this.#getColor(params.dialogColor)
@@ -47,8 +49,8 @@ export class Prompt {
 		this.#canvas.classList.add('odyc-prompt-canvas')
 
 		this.#resizeCanvas()
-		document.body.append(this.#canvas)
-		window.addEventListener('resize', this.#resizeCanvas)
+		this.#container.append(this.#canvas)
+		this.#container.addEventListener('resize', this.#resizeCanvas)
 	}
 
 	get #rect() {
@@ -165,9 +167,12 @@ export class Prompt {
 	}
 
 	#resizeCanvas = () => {
-		const sideSize = Math.min(window.innerWidth, window.innerHeight)
-		const left = (window.innerWidth - sideSize) * 0.5
-		const top = (window.innerHeight - sideSize) * 0.5
+		const sideSize = Math.min(
+			this.#container.clientWidth,
+			this.#container.clientHeight,
+		)
+		const left = (this.#container.clientWidth - sideSize) * 0.5
+		const top = (this.#container.clientHeight - sideSize) * 0.5
 		this.#canvas.style.setProperty('width', `${sideSize}px`)
 		this.#canvas.style.setProperty('height', `${sideSize}px`)
 		this.#canvas.style.setProperty('left', `${left}px`)
@@ -194,4 +199,5 @@ export class Prompt {
 	}
 }
 
-export const initPrompt = (params: DialogParams) => new Prompt(params)
+export const initPrompt = (params: DialogParams, container: HTMLElement) =>
+	new Prompt(params, container)

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -18,6 +18,7 @@ export type RendererParams = {
 
 class Renderer {
 	canvas: HTMLCanvasElement
+	#container: HTMLElement
 	#zoom = 24
 	screenWidth: number
 	screenHeight: number
@@ -27,7 +28,9 @@ class Renderer {
 	ctx: CanvasRenderingContext2D
 	background?: string | number
 
-	constructor(options: RendererParams) {
+	constructor(options: RendererParams, container: HTMLElement) {
+		this.#container = container
+
 		this.screenWidth = options.screenWidth
 		this.screenHeight = options.screenHeight
 		this.cellWidth = options.cellWidth
@@ -46,14 +49,17 @@ class Renderer {
 		if (!ctx) throw new Error('failled to access context of the canvas')
 		this.ctx = ctx
 		this.#setSize()
-		document.body.append(this.canvas)
+		this.#container.append(this.canvas)
 
-		window.addEventListener('resize', this.#setSize)
+		this.#container.addEventListener('resize', this.#setSize)
 	}
 	#setSize = () => {
 		const orientation =
 			this.canvas.width < this.canvas.height ? 'vertical' : 'horizontal'
-		const sideSize = Math.min(window.innerWidth, window.innerHeight)
+		const sideSize = Math.min(
+			this.#container.clientWidth,
+			this.#container.clientHeight,
+		)
 		let width =
 			orientation === 'horizontal'
 				? sideSize
@@ -62,8 +68,8 @@ class Renderer {
 			orientation === 'vertical'
 				? sideSize
 				: (sideSize / this.canvas.width) * this.canvas.height
-		const left = (window.innerWidth - width) * 0.5
-		const top = (window.innerHeight - height) * 0.5
+		const left = (this.#container.clientWidth - width) * 0.5
+		const top = (this.#container.clientHeight - height) * 0.5
 		this.canvas.style.setProperty('width', `${width}px`)
 		this.canvas.style.setProperty('height', `${height}px`)
 		this.canvas.style.setProperty('left', `${left}px`)
@@ -141,4 +147,5 @@ class Renderer {
 	}
 }
 
-export const initRenderer = (options: RendererParams) => new Renderer(options)
+export const initRenderer = (options: RendererParams, container: HTMLElement) =>
+	new Renderer(options, container)


### PR DESCRIPTION
Currently `odyc` binds canvases to `document.body`, however it would make things more flexible to allow users to specify a container they want everything loaded into. For instance, leveraging `odyc` in a specific area of a given site or within a react app.