### PR TITLE
Fix: Type miss-spelling

### DIFF
--- a/src/gameState/types.ts
+++ b/src/gameState/types.ts
@@ -9,7 +9,7 @@ export type Templates<T extends string = string> = {
 }
 
 export type Template<T extends string = string> = Partial<
-	Omit<ActorState<T>, 'position' | 'symbol' | 'isOonScreen'>
+	Omit<ActorState<T>, 'position' | 'symbol' | 'isOnScreen'>
 >
 
 export type GameStateParams<T extends string> = {


### PR DESCRIPTION
Omitting misspelled property made TypeScript allow it.