### PR TITLE
Feat: Custom global onInput event

### DIFF
--- a/src/createGame.ts
+++ b/src/createGame.ts
@@ -52,10 +52,9 @@ export const createGame = <T extends string>(
 			if (input === 'ACTION') messageBox.next()
 		} else if (dialog.isOpen) {
 			if (input === 'ACTION') dialog.next()
-		} else if (input !== 'ACTION') gameLoop.update(input)
-
-		if (config.onInput) {
-			config.onInput(input)
+		} else {
+			if (input !== 'ACTION') gameLoop.update(input)
+			gameState.player.dispatchOnInput(input)
 		}
 	})
 

--- a/src/gameState/player.ts
+++ b/src/gameState/player.ts
@@ -1,9 +1,11 @@
+import { Input } from '../inputs.js'
 import { createObservable, Observable } from '../lib/observer.js'
 import { Position, Tile } from '../types.js'
 
 export type PlayerParams = {
 	sprite?: Tile
 	position?: Position
+	onInput?: (input: Input) => any
 }
 
 export class Player {
@@ -11,6 +13,7 @@ export class Player {
 	#savedPosition: Position
 	#sprite: Tile | null
 	#position: Position
+	#onInput?: (input: Input) => any
 	#observable: Observable
 
 	constructor(params: PlayerParams) {
@@ -18,6 +21,7 @@ export class Player {
 		this.#savedPosition = params.position ?? [0, 0]
 		this.#sprite = params.sprite ?? null
 		this.#position = params.position ?? [0, 0]
+		this.#onInput = params.onInput
 		this.#observable = createObservable()
 	}
 
@@ -34,6 +38,10 @@ export class Player {
 		this.#sprite = this.#savedSprite
 		this.#position = [...this.#savedPosition]
 		this.#observable.notify()
+	}
+
+	dispatchOnInput(input: Input) {
+		this.#onInput?.(input)
 	}
 
 	get sprite() {

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -7,7 +7,6 @@ export type Input = 'LEFT' | 'UP' | 'RIGHT' | 'DOWN' | 'ACTION'
 export type InputsHandlerParams = {
 	controls: Record<Input, string | string[]>
 	autoFocus?: boolean
-	onInput?: (input: Input) => void
 }
 
 class InputsHandler {


### PR DESCRIPTION
I needed an ability to press SPACE (action key) on any grid spot.
This could probably be achieved by placing some mock sprite on every spot, even then, I couldn't find a way to run code when user does ACTION while standing on top of `solid: false` sprite. I saw some options talking to it (when standing beside), but not on top of.

If there is some way already, please let me know, but otherwise, this PR adds such option.

Quick QA on my project:

![CleanShot 2025-06-17 at 20 46 30@2x](https://github.com/user-attachments/assets/b9549747-f0ce-403f-b0ea-3a5bb32b012c)

![CleanShot 2025-06-17 at 20 46 34@2x](https://github.com/user-attachments/assets/70f3325c-3ce9-458b-9413-483a8def9be8)

I considered running onAction before handling Odyc's action, but only good reason to do so, would be ability for event to return `false`, preventing the action. This might be good idea. But then a question: Should it be able to prevent all actions (prompt, messageBox, dialog), or only actions that would go to game loop? Only game loop makes most sense, preventing dialog allows developer to break core functionality of odyc, which isnt ideal. But why would Odyc have ability to affect handling of input, but not fully? Only some small parts of it?

Due to above thoughts, I think it's best implemented as it is, until an issue is raised by developer who needs it implemented differently.

Open to discuss further, if needed.
