### PR TITLE
Fix: flaky tests

### DIFF
--- a/tests/visual/dialog-speed/index.test.ts
+++ b/tests/visual/dialog-speed/index.test.ts
@@ -13,20 +13,12 @@ test('dialog speed produces different visual states', async () => {
 	game1.openDialog(testMessage)
 	await new Promise((resolve) => setTimeout(resolve, 500))
 	const slowScreenshot = await page.screenshot({ base64: true, save: false })
-	// Try-catch prevents test failure from snapshot mismatch - we only care about speed differences
-	try {
-		await expect(slowScreenshot).toMatchImageSnapshot('slow')
-	} catch (error) {}
 
 	// Test NORMAL speed
 	const game2 = createGame({ dialogSpeed: 'NORMAL' })
 	game2.openDialog(testMessage)
 	await new Promise((resolve) => setTimeout(resolve, 500))
 	const normalScreenshot = await page.screenshot({ base64: true, save: false })
-	// Try-catch prevents test failure from snapshot mismatch - we only care about speed differences
-	try {
-		await expect(normalScreenshot).toMatchImageSnapshot('normal')
-	} catch (error) {}
 
 	// FAST speed (15ms) completes too quickly to test meaningfully with 500ms delay
 	// Main assertion: verify SLOW and NORMAL speeds produce different visual states

--- a/tests/visual/max-colors/index.test.ts
+++ b/tests/visual/max-colors/index.test.ts
@@ -2,11 +2,14 @@ import { expect, test } from 'vitest'
 import { init } from './index'
 import { page } from '@vitest/browser/context'
 import { registerImageSnapshot } from '../../toMatchImageSnapshot'
+import { tick } from '../../../dist'
 
 test('player can render colors', async () => {
 	registerImageSnapshot(expect)
 
+	const promise = tick()
 	const { game, state } = init()
+	await promise
 
 	const screenshot = await page.screenshot({ base64: true, save: false })
 	await expect(screenshot).toMatchImageSnapshot('init')

--- a/tests/visual/player-input-message/index.test.ts
+++ b/tests/visual/player-input-message/index.test.ts
@@ -3,11 +3,14 @@ import { init } from './index'
 import { page } from '@vitest/browser/context'
 import { registerImageSnapshot } from '../../toMatchImageSnapshot'
 import { userEvent } from '@vitest/browser/context'
+import { tick } from '../../../dist'
 
 test('message shows after input', async () => {
 	registerImageSnapshot(expect)
 
+	let promise = tick()
 	const { game, state } = init()
+	await promise
 
 	let screenshot
 
@@ -16,12 +19,16 @@ test('message shows after input', async () => {
 	await expect(screenshot).toMatchImageSnapshot('game')
 
 	// Wrong input, nothing changes
+	promise = tick()
 	await userEvent.keyboard('[ArrowDown]')
+	await promise
 	screenshot = await page.screenshot({ base64: true, save: false })
 	await expect(screenshot).toMatchImageSnapshot('game')
 
 	// Trigger message
+	promise = tick()
 	await userEvent.keyboard('[Space]')
+	await promise
 	screenshot = await page.screenshot({ base64: true, save: false })
 	await expect(screenshot).toMatchImageSnapshot('message')
 })

--- a/tests/visual/player-invisible/index.test.ts
+++ b/tests/visual/player-invisible/index.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest'
 import { init } from './index'
 import { page } from '@vitest/browser/context'
 import { registerImageSnapshot } from '../../toMatchImageSnapshot'
+import { tick } from '../../../dist/index'
 
 test('player is invisible but can be visible', async () => {
 	registerImageSnapshot(expect)
@@ -9,16 +10,21 @@ test('player is invisible but can be visible', async () => {
 	const { game, state } = init()
 
 	let screenshot
+	let promise
 
 	screenshot = await page.screenshot({ base64: true, save: false })
 	await expect(screenshot).toMatchImageSnapshot('no-player')
 
+	promise = tick()
 	game.player.visible = true
+	await promise
 
 	screenshot = await page.screenshot({ base64: true, save: false })
 	await expect(screenshot).toMatchImageSnapshot('player')
 
+	promise = tick()
 	game.player.visible = false
+	await promise
 
 	screenshot = await page.screenshot({ base64: true, save: false })
 	await expect(screenshot).toMatchImageSnapshot('no-player')

--- a/tests/visual/player-size/index.test.ts
+++ b/tests/visual/player-size/index.test.ts
@@ -2,11 +2,14 @@ import { expect, test } from 'vitest'
 import { init } from './index'
 import { page } from '@vitest/browser/context'
 import { registerImageSnapshot } from '../../toMatchImageSnapshot'
+import { tick } from '../../../dist'
 
 test('player renders in correct size', async () => {
 	registerImageSnapshot(expect)
 
+	const promise = tick()
 	const { game, state } = init()
+	await promise
 
 	const screenshot = await page.screenshot({ base64: true, save: false })
 	await expect(screenshot).toMatchImageSnapshot('init')

--- a/tests/visual/player-sprite/index.test.ts
+++ b/tests/visual/player-sprite/index.test.ts
@@ -2,11 +2,14 @@ import { expect, test } from 'vitest'
 import { init } from './index'
 import { page } from '@vitest/browser/context'
 import { registerImageSnapshot } from '../../toMatchImageSnapshot'
+import { tick } from '../../../dist'
 
 test('player can render colors', async () => {
 	registerImageSnapshot(expect)
 
+	const promise = tick()
 	const { game, state } = init()
+	await promise
 
 	const screenshot = await page.screenshot({ base64: true, save: false })
 	await expect(screenshot).toMatchImageSnapshot('init')

--- a/tests/visual/player-visible/index.test.ts
+++ b/tests/visual/player-visible/index.test.ts
@@ -2,6 +2,7 @@ import { expect, test } from 'vitest'
 import { init } from './index'
 import { page } from '@vitest/browser/context'
 import { registerImageSnapshot } from '../../toMatchImageSnapshot'
+import { tick } from '../../../dist'
 
 test('player is visible but can be invisible', async () => {
 	registerImageSnapshot(expect)
@@ -9,16 +10,21 @@ test('player is visible but can be invisible', async () => {
 	const { game, state } = init()
 
 	let screenshot
+	let promise
 
 	screenshot = await page.screenshot({ base64: true, save: false })
 	await expect(screenshot).toMatchImageSnapshot('player')
 
+	promise = tick()
 	game.player.visible = false
+	await promise
 
 	screenshot = await page.screenshot({ base64: true, save: false })
 	await expect(screenshot).toMatchImageSnapshot('no-player')
 
+	promise = tick()
 	game.player.visible = true
+	await promise
 
 	screenshot = await page.screenshot({ base64: true, save: false })
 	await expect(screenshot).toMatchImageSnapshot('player')

--- a/tests/visual/template-foreground/index.test.ts
+++ b/tests/visual/template-foreground/index.test.ts
@@ -2,11 +2,14 @@ import { expect, test } from 'vitest'
 import { init } from './index'
 import { page } from '@vitest/browser/context'
 import { registerImageSnapshot } from '../../toMatchImageSnapshot'
+import { tick } from '../../../dist'
 
 test('renders foreground templates above the player', async () => {
 	registerImageSnapshot(expect)
 
+	const promise = tick()
 	const { game, state } = init()
+	await promise
 
 	const screenshot = await page.screenshot({ base64: true, save: false })
 	await expect(screenshot).toMatchImageSnapshot('init')

--- a/tests/visual/template-visible/index.test.ts
+++ b/tests/visual/template-visible/index.test.ts
@@ -2,11 +2,14 @@ import { expect, test } from 'vitest'
 import { init } from './index'
 import { page } from '@vitest/browser/context'
 import { registerImageSnapshot } from '../../toMatchImageSnapshot'
+import { tick } from '../../../dist'
 
 test('template is not rendered when visible is false', async () => {
 	registerImageSnapshot(expect)
 
+	const promise = tick()
 	const { game, state } = init()
+	await promise
 
 	const screenshot = await page.screenshot({ base64: true, save: false })
 	await expect(screenshot).toMatchImageSnapshot('init')

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,6 @@ import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
 	test: {
-		retry: 5, // Temporary solution to flaky visual tests until they can await canvas render
 		browser: {
 			viewport: { height: 512, width: 512 },
 			enabled: true,


### PR DESCRIPTION
Visual tests were flaky, because screenshot was sometimes taken before canvas render finished.
With introduction of tick helper, tests can now be optimized to prevent this flakyness.