### PR TITLE
fix: do not run onTurn events when map changed

### DIFF
--- a/packages/odyc/src/gameLoop.ts
+++ b/packages/odyc/src/gameLoop.ts
@@ -37,10 +37,8 @@ class GameLoop<T extends string> {
 
 		const onTurnEvents = this.#gameState.cells
 			.get()
-			.map((el) => this.#gameState.cells.getEvent(...el.position, 'onTurn'))
+			.filter((cell) => cell.onTurn)
 
-		// map may change while on* events are being handled
-		const mapBeforeEvents = this.#gameState.gameMap.map;
 		if (this.#isCellOnworld(to.value)) {
 			const cell = this.#gameState.cells.getCellAt(...to.value)
 
@@ -56,13 +54,10 @@ class GameLoop<T extends string> {
 				await this.#gameState.cells.getEvent(...to.value, 'onCollide')?.()
 			else await this.#gameState.cells.getEvent(...to.value, 'onEnter')?.()
 		}
-		// run turn events only if map didn't change
-		if (this.#gameState.gameMap.map === mapBeforeEvents) {
-			for (const event of onTurnEvents) {
-				await event?.()
-			}
-			this.#gameState.player.dispatchOnTurn()
+		for (const cell of onTurnEvents) {
+			await this.#gameState.cells.getEvent(...cell.position, 'onTurn')?.()
 		}
+		this.#gameState.player.dispatchOnTurn()
 		if (!this.#ender.ending) this.#gameState.turn.next()
 		await this.#end(this.#gameState.cells.getCellAt(...to.value))
 	}

--- a/tests/odyc-e2e/functional/on-turn/index.test.ts
+++ b/tests/odyc-e2e/functional/on-turn/index.test.ts
@@ -39,5 +39,50 @@ describe('onTurn events', () => {
 		expect(turnSpy).toHaveBeenCalledOnce()
 	})
 
-	// test('should call onTurn for newly created actors on subsequent turns', async () => {})
+	test('should call onTurn for newly created actors on subsequent turns', async () => {
+		const turnSpy = vi.fn()
+		const game = createGame({
+			templates: {
+				x: {
+					onTurn() {
+						game.setCellAt(1, 0, 'y')
+					},
+				},
+				'.': {},
+				y: {
+					onTurn: turnSpy,
+				},
+			},
+			map: `x.`,
+		})
+
+		// First turn - x creates y
+		await userEvent.keyboard('[ArrowLeft]')
+		expect(turnSpy).not.toHaveBeenCalled()
+
+		// Second turn - y should have onTurn called
+		await userEvent.keyboard('[ArrowLeft]')
+		expect(turnSpy).toHaveBeenCalledOnce()
+	})
+
+	test('should not call onTurn for cells removed during the turn', async () => {
+		const turnSpy = vi.fn()
+		const game = createGame({
+			templates: {
+				x: {
+					onCollide() {
+						game.clearCellAt(0, 0)
+					},
+				},
+				y: {
+					onTurn: turnSpy,
+				},
+			},
+			map: `yx`,
+		})
+
+		// Move right to collide with x, which clears y during the collision
+		await userEvent.keyboard('[ArrowRight]')
+		expect(turnSpy).not.toHaveBeenCalled()
+	})
 })


### PR DESCRIPTION
If map changes while the `onLeave`, `onCollide` or `onEnter` events are handled, then `onTurn` will not run with correct cells.

Fixes #40

Note: there is one corner case not fixed: if map is changed during `onLeave`, `onEnter` will still run as if the map was not changed.