### PR TITLE
feat: add git commit hash to bundled module

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"test:once": "npm run test:once --workspace=odyc-e2e",
 		"build": "npm run build --workspace=odyc",
 		"prepublishOnly": "npm run lint && npm run build && npm run test:once",
-		"release": "npm run prepublishOnly && npm version patch --workspace=odyc && npm publish --workspace=odyc --access public && git push --follow-tags && gh release create v$(node -p \"require('./packages/odyc/package.json').version\") --generate-notes"
+		"release": "npm run prepublishOnly && npm version patch --workspace=odyc && npm run build && npm publish --workspace=odyc --access public && git push --follow-tags && gh release create v$(node -p \"require('./packages/odyc/package.json').version\") --generate-notes"
 	},
 	"devDependencies": {
 		"prettier": "^3.6.2"

--- a/packages/odyc/src/index.ts
+++ b/packages/odyc/src/index.ts
@@ -3,7 +3,17 @@ import { type CellFacade } from './gameState/cellFacade.js'
 import { Template } from './gameState/types.js'
 import { createSound } from './sound.js'
 
+// Global constants injected at build time by tsup
+declare const __GIT_HASH__: string
+declare const __PACKAGE_VERSION__: string
+
 export * from './helpers'
 export { createGame, createSound }
 
 export type { CellFacade as Cell, Template }
+
+// Build information available at runtime
+export const __BUILD_INFO__ = {
+	gitHash: __GIT_HASH__,
+	version: __PACKAGE_VERSION__,
+} as const

--- a/packages/odyc/tsup.config.ts
+++ b/packages/odyc/tsup.config.ts
@@ -1,4 +1,24 @@
 import { defineConfig } from 'tsup'
+import { execSync } from 'child_process'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+function getGitHash() {
+	try {
+		return execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim()
+	} catch {
+		return 'unknown'
+	}
+}
+
+function getPackageVersion() {
+	try {
+		const packageJson = JSON.parse(readFileSync(join(__dirname, 'package.json'), 'utf8'))
+		return packageJson.version
+	} catch {
+		return 'unknown'
+	}
+}
 
 export default defineConfig({
 	dts: true, // Generate .d.ts files
@@ -13,5 +33,9 @@ export default defineConfig({
 	injectStyle: true,
 	loader: {
 		'.glsl': 'text',
+	},
+	define: {
+		__GIT_HASH__: JSON.stringify(getGitHash()),
+		__PACKAGE_VERSION__: JSON.stringify(getPackageVersion()),
 	},
 })


### PR DESCRIPTION
- Use tsup's define feature to inject values during build process
- Export __BUILD_INFO__ object with runtime access to build metadata
- Available in both ESM and IIFE builds with TypeScript declarations